### PR TITLE
Ability to set multiple properties at once

### DIFF
--- a/src/com/yusufcihan/DynamicComponents/DynamicComponents.java
+++ b/src/com/yusufcihan/DynamicComponents/DynamicComponents.java
@@ -17,11 +17,14 @@ import java.util.Hashtable;
 import java.util.List;
 import java.util.Set;
 
-@DesignerComponent(version = 5,
+@DesignerComponent(
+	version = 5,
+	versionName = "1.5",
         description = "Dynamic Components extension to create any type of dynamic component in any arrangement.<br><br>- by Yusuf Cihan",
         category = ComponentCategory.EXTENSION,
         nonVisible = true,
-        iconName = "https://yusufcihan.com/img/dynamiccomponents.png")
+        iconName = "https://yusufcihan.com/img/dynamiccomponents.png"
+)
 @SimpleObject(external = true)
 public class DynamicComponents extends AndroidNonvisibleComponent implements Component {
 


### PR DESCRIPTION
- Descriptions have been modified to remove the unnecessary `+` and `\n`
- You can now set multiple properties at once!

### Example for setting multiple properties at once
```
SetProperties(component, "{
  "AlignVertical": 2,
  "FullClickable": true
}");
```

The above JSON Object can also be achieved using dictionaries as below.

![blocks (5)](https://user-images.githubusercontent.com/43486313/90953887-4d586c80-e43d-11ea-8096-da3b6f254bbf.png)
