### PR TITLE
Get component metadata no matter the circumstance + Others

### DIFF
--- a/src/com/yusufcihan/DynamicComponents/DynamicComponents.java
+++ b/src/com/yusufcihan/DynamicComponents/DynamicComponents.java
@@ -111,6 +111,15 @@ public class DynamicComponents extends AndroidNonvisibleComponent {
 
       return null;
     }
+    
+    public boolean isEmptyOrNull(Object item) {
+      if (item instanceOf String) {
+        item = item.replace(" ", "");
+        return item.isEmpty();
+      }
+      
+      return item == null;
+    }
 
     public void newInstance(Constructor<?> constructor, String id, AndroidViewComponent input) {
       Component mComponent = null;
@@ -250,7 +259,8 @@ public class DynamicComponents extends AndroidNonvisibleComponent {
     SimpleObject mObjectAnnotation = mClass.getAnnotation(SimpleObject.class);
     YailDictionary mMeta = new YailDictionary();
 
-    if (mDesignerAnnotation != null) {
+    if (mDesignerAnnotation != null && mObjectAnnotation != null) {
+      // Return all metadata
       mMeta.put("androidMinSdk", mDesignerAnnotation.androidMinSdk());
       mMeta.put("category", mDesignerAnnotation.category());
       mMeta.put("dateBuilt", mDesignerAnnotation.dateBuilt());
@@ -265,6 +275,12 @@ public class DynamicComponents extends AndroidNonvisibleComponent {
       mMeta.put("type", mClass.getSimpleName());
       mMeta.put("version", mDesignerAnnotation.version());
       mMeta.put("versionName", mDesignerAnnotation.versionName());
+    } else if (mDesignerAnnotation == null && mObjectAnnotation != null) {
+      // Return even the smallest amount of metadata even if there is no
+      // @DesignerComponent annotation
+      mMeta.put("external", mObjectAnnotation.external());
+      mMeta.put("package", mClass.getName());
+      mMeta.put("type", mClass.getSimpleName());
     }
 
     return mMeta;

--- a/src/com/yusufcihan/DynamicComponents/DynamicComponents.java
+++ b/src/com/yusufcihan/DynamicComponents/DynamicComponents.java
@@ -370,7 +370,7 @@ public class DynamicComponents extends AndroidNonvisibleComponent {
   public int GetOrder(AndroidViewComponent component) {
     View mComponent = (View) component.getView();
     int mIndex = 0;
-    ViewGroup mParent = (mComponent != null ? (ViewGroup) mComponent.getParent() : null);
+    ViewGroup mParent = (!isEmptyOrNull(mComponent) ? (ViewGroup) mComponent.getParent() : null);
 
     if (!isEmptyOrNull(mComponent) && !isEmptyOrNull(mParent)) {
       mIndex = mParent.indexOfChild(mComponent) + 1;
@@ -484,7 +484,7 @@ public class DynamicComponents extends AndroidNonvisibleComponent {
   @SimpleFunction(description = "Moves the specified component to the specified view.")
   public void Move(AndroidViewComponent arrangement, AndroidViewComponent component) {
     View mComponent = (View) component.getView();
-    ViewGroup mParent = (mComponent != null ? (ViewGroup) mComponent.getParent() : null);
+    ViewGroup mParent = (!isEmptyOrNull(mComponent) ? (ViewGroup) mComponent.getParent() : null);
 
     mParent.removeView(mComponent);
 
@@ -567,7 +567,7 @@ public class DynamicComponents extends AndroidNonvisibleComponent {
     JSONObject mScheme = new JSONObject(template);
     String newTemplate = template;
 
-    if (!template.replace(" ", "").isEmpty() && mScheme.has("components")) {
+    if (!isEmptyOrNull(template) && mScheme.has("components")) {
       propertiesArray = new JSONArray();
 
       JSONArray mKeys = (mScheme.has("keys") ? mScheme.getJSONArray("keys") : null);

--- a/src/com/yusufcihan/DynamicComponents/DynamicComponents.java
+++ b/src/com/yusufcihan/DynamicComponents/DynamicComponents.java
@@ -46,8 +46,8 @@ import java.util.UUID;
   helpUrl = "https://github.com/ysfchn/DynamicComponents-AI2/blob/main/README.md",
   iconName = "aiwebres/icon.png",
   nonVisible = true,
-  version = 9,
-  versionName = "2.2.2"
+  version = 8,
+  versionName = "2.2.1"
 )
 @SimpleObject(external = true)
 public class DynamicComponents extends AndroidNonvisibleComponent {
@@ -234,8 +234,6 @@ public class DynamicComponents extends AndroidNonvisibleComponent {
       } else {
         UTIL_INSTANCE.newInstance(mConstructor, id, in);
       }
-
-      ComponentCreated(id.toString(), mClass.getSimpleName());
     } else {
       throw new YailRuntimeError("ID must be unique.", "DynamicComponents");
     }

--- a/src/com/yusufcihan/DynamicComponents/DynamicComponents.java
+++ b/src/com/yusufcihan/DynamicComponents/DynamicComponents.java
@@ -302,15 +302,22 @@ public class DynamicComponents extends AndroidNonvisibleComponent {
 
     for (Method mMethod : mMethods) {
       SimpleEvent mAnnotation = mMethod.getAnnotation(SimpleEvent.class);
+      boolean mIsDeprecated = !isEmptyOrNull(mMethod.getAnnotation(Deprecated.class));
       String mName = mMethod.getName();
       YailDictionary mEventMeta = new YailDictionary();
 
       if (!isEmptyOrNull(mAnnotation)) {
+        // Return all metadata
         mEventMeta.put("description", mAnnotation.description());
-        mEventMeta.put("isDeprecated", (mMethod.getAnnotation(Deprecated.class) != null));
+        mEventMeta.put("isDeprecated", mIsDeprecated);
         mEventMeta.put("userVisible", mAnnotation.userVisible());
-        mEvents.put(mName, mEventMeta);
+      } else {
+        // Return the least amount of metadata if no
+        // annotation is provided
+        mEventMeta.put("isDeprecated", mIsDeprecated);
       }
+      
+      mEvents.put(mName, mEventMeta);
     }
 
     return mEvents;
@@ -323,15 +330,22 @@ public class DynamicComponents extends AndroidNonvisibleComponent {
 
     for (Method mMethod : mMethods) {
       SimpleFunction mAnnotation = mMethod.getAnnotation(SimpleFunction.class);
+      boolean mIsDeprecated = !isEmptyOrNull(mMethod.getAnnotation(Deprecated.class));
       String mName = mMethod.getName();
       YailDictionary mFunctionMeta = new YailDictionary();
 
       if (!isEmptyOrNull(mAnnotation)) {
+        // Return all metadata
         mFunctionMeta.put("description", mAnnotation.description());
-        mFunctionMeta.put("isDeprecated", (mMethod.getAnnotation(Deprecated.class) != null));
+        mFunctionMeta.put("isDeprecated", mIsDeprecated);
         mFunctionMeta.put("userVisible", mAnnotation.userVisible());
-        mFunctions.put(mName, mFunctionMeta);
+      } else {
+        // Return the least amount of metadata if no
+        // annotation is provided
+        mFunctionMeta.put("isDeprecated", mIsDeprecated);
       }
+      
+      mFunctions.put(mName, mFunctionMeta);
     }
 
     return mFunctions;

--- a/src/com/yusufcihan/DynamicComponents/DynamicComponents.java
+++ b/src/com/yusufcihan/DynamicComponents/DynamicComponents.java
@@ -160,8 +160,9 @@ public class DynamicComponents extends AndroidNonvisibleComponent {
   
   public boolean isEmptyOrNull(Object item) {
     if (item instanceof String) {
-      item = item.replace(" ", "");
-      return item.isEmpty();
+      String mItem = item.toString();
+      mItem = mItem.replace(" ", "");
+      return mItem.isEmpty();
     }
 
     return item == null;
@@ -257,7 +258,7 @@ public class DynamicComponents extends AndroidNonvisibleComponent {
     Class<?> mClass = component.getClass();
     DesignerComponent mDesignerAnnotation = mClass.getAnnotation(DesignerComponent.class);
     boolean mHasDesigner = !isEmptyOrNull(mDesignerAnnotation);
-    boolean mHasObject = null;
+    boolean mHasObject = false;
     SimpleObject mObjectAnnotation = mClass.getAnnotation(SimpleObject.class);
     YailDictionary mMeta = new YailDictionary();
     mHasObject = !isEmptyOrNull(mObjectAnnotation);
@@ -377,7 +378,7 @@ public class DynamicComponents extends AndroidNonvisibleComponent {
     for (Method mMethod : mMethods) {
       DesignerProperty mDesignerAnnotation = mMethod.getAnnotation(DesignerProperty.class);
       boolean mHasDesigner = !isEmptyOrNull(mDesignerAnnotation);
-      boolean mHasProperty = null;
+      boolean mHasProperty = false;
       SimpleProperty mPropertyAnnotation = mMethod.getAnnotation(SimpleProperty.class);
       String mName = mMethod.getName();
       YailDictionary mPropertyMeta = new YailDictionary();

--- a/src/com/yusufcihan/DynamicComponents/DynamicComponents.java
+++ b/src/com/yusufcihan/DynamicComponents/DynamicComponents.java
@@ -235,7 +235,7 @@ public class DynamicComponents extends AndroidNonvisibleComponent {
         UTIL_INSTANCE.newInstance(mConstructor, id, in);
       }
     } else {
-      throw new YailRuntimeError("ID must be unique.", "DynamicComponents");
+      throw new YailRuntimeError("Expected a unique ID, got '" + id + "'.", "DynamicComponents");
     }
   }
 

--- a/src/com/yusufcihan/DynamicComponents/DynamicComponents.java
+++ b/src/com/yusufcihan/DynamicComponents/DynamicComponents.java
@@ -46,8 +46,8 @@ import java.util.UUID;
   helpUrl = "https://github.com/ysfchn/DynamicComponents-AI2/blob/main/README.md",
   iconName = "aiwebres/icon.png",
   nonVisible = true,
-  version = 8,
-  versionName = "2.2.1"
+  version = 9,
+  versionName = "2.2.2"
 )
 @SimpleObject(external = true)
 public class DynamicComponents extends AndroidNonvisibleComponent {


### PR DESCRIPTION
### This PR introduces...
- [x] A helper function (`isEmptyOrNull`) to make comparisons between objects easier, instead of reusing longer code.
- [x] A patch that fixes all events not being handled.
  - <s>All events were tested in both `Main` and `UI` environments.</s>
  - <s>Events can be handled by invoking them (it's weird that this is the only way).</s>
  - Fixed in both environments by https://github.com/ysfchn/DynamicComponents-AI2/pull/41/commits/ab1eff2593f013c5e2dec35351aa88d87bc72680.
- [x] The ability to get metadata about a component, an event, or function if no annotations are provided.